### PR TITLE
Add donegroup.Awaiter

### DIFF
--- a/donegroup.go
+++ b/donegroup.go
@@ -65,9 +65,9 @@ func CleanupWithKey(ctx context.Context, key any, f func(ctx context.Context) er
 		<-ctx.Done()
 		<-dg._ctx.Done()
 		dg.mu.Lock()
-		ctx := dg.ctxw
+		ctxw := dg.ctxw
 		dg.mu.Unlock()
-		return f(ctx)
+		return f(ctxw)
 	})
 	return nil
 }
@@ -116,4 +116,27 @@ func WaitWithContextAndKey(ctx, ctxw context.Context, key any) error {
 	}
 
 	return eg.Wait()
+}
+
+// Awaiter returns a function that guarantees execution of the process until it is called.
+// Note that if the timeout of WaitWithTimeout has passed (or the context of WaitWithContext has canceled), it will not wait.
+func Awaiter(ctx context.Context) (completed func()) {
+	return AwaiterWithKey(ctx, doneGroupKey)
+}
+
+// AwaiterWithKey returns a function that guarantees execution of the process until it is called.
+// Note that if the timeout of WaitWithTimeout has passed (or the context of WaitWithContext has canceled), it will not wait.
+func AwaiterWithKey(ctx context.Context, key any) (completed func()) {
+	ctxx, completed := context.WithCancel(context.Background())
+	CleanupWithKey(ctx, key, func(ctxw context.Context) error {
+		for {
+			select {
+			case <-ctxw.Done():
+				return ctxw.Err()
+			case <-ctxx.Done():
+				return nil
+			}
+		}
+	})
+	return completed
 }

--- a/donegroup.go
+++ b/donegroup.go
@@ -11,7 +11,7 @@ import (
 
 var doneGroupKey = struct{}{}
 
-// doneGroup is cleanup function groups per Context
+// doneGroup is cleanup function groups per Context.
 type doneGroup struct {
 	// ctxw is the context used to call the cleanup functions
 	ctxw          context.Context
@@ -128,7 +128,7 @@ func Awaiter(ctx context.Context) (completed func()) {
 // Note that if the timeout of WaitWithTimeout has passed (or the context of WaitWithContext has canceled), it will not wait.
 func AwaiterWithKey(ctx context.Context, key any) (completed func()) {
 	ctxx, completed := context.WithCancel(context.Background())
-	CleanupWithKey(ctx, key, func(ctxw context.Context) error {
+	if err := CleanupWithKey(ctx, key, func(ctxw context.Context) error {
 		for {
 			select {
 			case <-ctxw.Done():
@@ -137,6 +137,8 @@ func AwaiterWithKey(ctx context.Context, key any) (completed func()) {
 				return nil
 			}
 		}
-	})
+	}); err != nil {
+		panic(err)
+	}
 	return completed
 }


### PR DESCRIPTION
In addition to using donegroup.Cleanup to register a cleanup function after context cancellation, it is possible to use donegroup.Awaiter to make the execution of an arbitrary process wa\
it after the context has been canceled.

``` go
ctx, cancel := donegroup.WithCancel(context.Background())

go func() {
    completed := donegroup.Awaiter(ctx)
    for {
        select {
        case <-ctx.Done():
            time.Sleep(100 * time.Millisecond)
            fmt.Println("cleanup")
            completed()
            return
        case <-time.After(10 * time.Millisecond):
            fmt.Println("do something")
        }
    }
}()

// Main process of some kind
fmt.Println("main")
time.Sleep(35 * time.Millisecond)

cancel()
if err := donegroup.Wait(ctx); err != nil {
    log.Fatal(err)
}

// Output:
// main
// do something
// do something
// do something
// cleanup
```