### PR TITLE
Add Cancel for canceling context and waiting for cleanup functions at once.

### DIFF
--- a/donegroup.go
+++ b/donegroup.go
@@ -90,19 +90,19 @@ func WaitWithContext(ctx, ctxw context.Context) error {
 	return WaitWithContextAndKey(ctx, ctxw, doneGroupKey)
 }
 
-// CancelAndWait cancels the context. Then calls the function registered by Cleanup.
-func CancelAndWait(ctx context.Context) error {
-	return CancelAndWaitWithKey(ctx, doneGroupKey)
+// Cancel cancels the context. Then calls the function registered by Cleanup.
+func Cancel(ctx context.Context) error {
+	return CancelWithKey(ctx, doneGroupKey)
 }
 
-// CancelAndWaitWithTimeout cancels the context. Then calls the function registered by Cleanup with timeout.
-func CancelAndWaitWithTimeout(ctx context.Context, timeout time.Duration) error {
-	return CancelAndWaitWithTimeoutAndKey(ctx, timeout, doneGroupKey)
+// CancelWithTimeout cancels the context. Then calls the function registered by Cleanup with timeout.
+func CancelWithTimeout(ctx context.Context, timeout time.Duration) error {
+	return CancelWithTimeoutAndKey(ctx, timeout, doneGroupKey)
 }
 
-// CancelAndWaitWithContext cancels the context. Then calls the function registered by Cleanup with context (ctxw).
-func CancelAndWaitWithContext(ctx, ctxw context.Context) error {
-	return CancelAndWaitWithContextAndKey(ctx, ctxw, doneGroupKey)
+// CancelWithContext cancels the context. Then calls the function registered by Cleanup with context (ctxw).
+func CancelWithContext(ctx, ctxw context.Context) error {
+	return CancelWithContextAndKey(ctx, ctxw, doneGroupKey)
 }
 
 // WaitWithKey blocks until the context is canceled. Then calls the function registered by Cleanup.
@@ -136,20 +136,20 @@ func WaitWithContextAndKey(ctx, ctxw context.Context, key any) error {
 	return eg.Wait()
 }
 
-// CancelAndWaitWithKey cancels the context. Then calls the function registered by Cleanup.
-func CancelAndWaitWithKey(ctx context.Context, key any) error {
-	return CancelAndWaitWithContextAndKey(ctx, context.Background(), key)
+// CancelWithKey cancels the context. Then calls the function registered by Cleanup.
+func CancelWithKey(ctx context.Context, key any) error {
+	return CancelWithContextAndKey(ctx, context.Background(), key)
 }
 
-// CancelAndWaitWithTimeoutAndKey cancels the context. Then calls the function registered by Cleanup with timeout.
-func CancelAndWaitWithTimeoutAndKey(ctx context.Context, timeout time.Duration, key any) error {
+// CancelWithTimeoutAndKey cancels the context. Then calls the function registered by Cleanup with timeout.
+func CancelWithTimeoutAndKey(ctx context.Context, timeout time.Duration, key any) error {
 	ctxw, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	return CancelAndWaitWithContextAndKey(ctx, ctxw, key)
+	return CancelWithContextAndKey(ctx, ctxw, key)
 }
 
-// CancelAndWaitWithContextAndKey cancels the context. Then calls the function registered by Cleanup with context (ctxw).
-func CancelAndWaitWithContextAndKey(ctx, ctxw context.Context, key any) error {
+// CancelWithContextAndKey cancels the context. Then calls the function registered by Cleanup with context (ctxw).
+func CancelWithContextAndKey(ctx, ctxw context.Context, key any) error {
 	dg, ok := ctx.Value(key).(*doneGroup)
 	if !ok {
 		return errors.New("donegroup: context does not contain a doneGroup. Use donegroup.WithCancel to create a context with a doneGroup")

--- a/donegroup.go
+++ b/donegroup.go
@@ -13,6 +13,7 @@ var doneGroupKey = struct{}{}
 
 // doneGroup is cleanup function groups per Context.
 type doneGroup struct {
+	cancel context.CancelFunc
 	// ctxw is the context used to call the cleanup functions
 	ctxw          context.Context
 	cleanupGroups []*errgroup.Group
@@ -29,11 +30,12 @@ func WithCancel(ctx context.Context) (context.Context, context.CancelFunc) {
 
 // WithCancelWithKey returns a copy of parent with a new Done channel and a doneGroup.
 func WithCancelWithKey(ctx context.Context, key any) (context.Context, context.CancelFunc) {
-	secondCtx, secondCancel := context.WithCancel(ctx)
+	dgCtx, dgCancel := context.WithCancel(ctx)
 	dg, ok := ctx.Value(key).(*doneGroup)
 	if !ok {
 		ctx, cancel := context.WithCancel(context.Background())
 		dg = &doneGroup{
+			cancel:  dgCancel,
 			_ctx:    ctx,
 			_cancel: cancel,
 		}
@@ -41,11 +43,12 @@ func WithCancelWithKey(ctx context.Context, key any) (context.Context, context.C
 	eg := new(errgroup.Group)
 	dg.cleanupGroups = append(dg.cleanupGroups, eg)
 	secondDg := &doneGroup{
+		cancel:        dgCancel,
 		_ctx:          dg._ctx,
 		_cancel:       dg._cancel,
 		cleanupGroups: []*errgroup.Group{eg},
 	}
-	return context.WithValue(secondCtx, key, secondDg), secondCancel
+	return context.WithValue(dgCtx, key, secondDg), dgCancel
 }
 
 // Cleanup registers a function to be called when the context is canceled.
@@ -87,6 +90,21 @@ func WaitWithContext(ctx, ctxw context.Context) error {
 	return WaitWithContextAndKey(ctx, ctxw, doneGroupKey)
 }
 
+// CancelAndWait cancels the context. Then calls the function registered by Cleanup.
+func CancelAndWait(ctx context.Context) error {
+	return CancelAndWaitWithKey(ctx, doneGroupKey)
+}
+
+// CancelAndWaitWithTimeout cancels the context. Then calls the function registered by Cleanup with timeout.
+func CancelAndWaitWithTimeout(ctx context.Context, timeout time.Duration) error {
+	return CancelAndWaitWithTimeoutAndKey(ctx, timeout, doneGroupKey)
+}
+
+// CancelAndWaitWithContext cancels the context. Then calls the function registered by Cleanup with context (ctxw).
+func CancelAndWaitWithContext(ctx, ctxw context.Context) error {
+	return CancelAndWaitWithContextAndKey(ctx, ctxw, doneGroupKey)
+}
+
 // WaitWithKey blocks until the context is canceled. Then calls the function registered by Cleanup.
 func WaitWithKey(ctx context.Context, key any) error {
 	return WaitWithContextAndKey(ctx, context.Background(), key)
@@ -116,6 +134,28 @@ func WaitWithContextAndKey(ctx, ctxw context.Context, key any) error {
 	}
 
 	return eg.Wait()
+}
+
+// CancelAndWaitWithKey cancels the context. Then calls the function registered by Cleanup.
+func CancelAndWaitWithKey(ctx context.Context, key any) error {
+	return CancelAndWaitWithContextAndKey(ctx, context.Background(), key)
+}
+
+// CancelAndWaitWithTimeoutAndKey cancels the context. Then calls the function registered by Cleanup with timeout.
+func CancelAndWaitWithTimeoutAndKey(ctx context.Context, timeout time.Duration, key any) error {
+	ctxw, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return CancelAndWaitWithContextAndKey(ctx, ctxw, key)
+}
+
+// CancelAndWaitWithContextAndKey cancels the context. Then calls the function registered by Cleanup with context (ctxw).
+func CancelAndWaitWithContextAndKey(ctx, ctxw context.Context, key any) error {
+	dg, ok := ctx.Value(key).(*doneGroup)
+	if !ok {
+		return errors.New("donegroup: context does not contain a doneGroup. Use donegroup.WithCancel to create a context with a doneGroup")
+	}
+	dg.cancel()
+	return WaitWithContextAndKey(ctx, ctxw, key)
 }
 
 // Awaiter returns a function that guarantees execution of the process until it is called.

--- a/donegroup_test.go
+++ b/donegroup_test.go
@@ -348,26 +348,26 @@ func TestAwaiter(t *testing.T) {
 	}
 }
 
-func TestCancelAndWait(t *testing.T) {
+func TestCancel(t *testing.T) {
 	t.Parallel()
-	t.Run("CancelAndWait with WithCancel", func(t *testing.T) {
+	t.Run("Cancel with WithCancel", func(t *testing.T) {
 		ctx, _ := WithCancel(context.Background())
-		err := CancelAndWait(ctx)
+		err := Cancel(ctx)
 		if err != nil {
 			t.Error(err)
 		}
 	})
 
-	t.Run("CancelAndWait without WithCancel", func(t *testing.T) {
+	t.Run("Cancel without WithCancel", func(t *testing.T) {
 		ctx := context.Background()
-		err := CancelAndWait(ctx)
+		err := Cancel(ctx)
 		if err == nil {
 			t.Error("expected error, got nil")
 		}
 	})
 }
 
-func TestCancelAndWaitWithTimeout(t *testing.T) {
+func TestCancelWithTimeout(t *testing.T) {
 	t.Parallel()
 	ctx, _ := WithCancel(context.Background())
 
@@ -389,13 +389,13 @@ func TestCancelAndWaitWithTimeout(t *testing.T) {
 
 	defer func() {
 		time.Sleep(10 * time.Millisecond)
-		if err := CancelAndWaitWithTimeout(ctx, timeout); !errors.Is(err, context.DeadlineExceeded) {
+		if err := CancelWithTimeout(ctx, timeout); !errors.Is(err, context.DeadlineExceeded) {
 			t.Error("expected timeout error")
 		}
 	}()
 }
 
-func TestCancelAndWaitWithContext(t *testing.T) {
+func TestCancelWithContext(t *testing.T) {
 	t.Parallel()
 	ctx, _ := WithCancel(context.Background())
 
@@ -419,7 +419,7 @@ func TestCancelAndWaitWithContext(t *testing.T) {
 		ctxx, cancelx := context.WithTimeout(context.Background(), timeout)
 		defer cancelx()
 		time.Sleep(10 * time.Millisecond)
-		if err := CancelAndWaitWithContext(ctx, ctxx); !errors.Is(err, context.DeadlineExceeded) {
+		if err := CancelWithContext(ctx, ctxx); !errors.Is(err, context.DeadlineExceeded) {
 			t.Error("expected timeout error")
 		}
 	}()

--- a/donegroup_test.go
+++ b/donegroup_test.go
@@ -347,3 +347,80 @@ func TestAwaiter(t *testing.T) {
 		})
 	}
 }
+
+func TestCancelAndWait(t *testing.T) {
+	t.Parallel()
+	t.Run("CancelAndWait with WithCancel", func(t *testing.T) {
+		ctx, _ := WithCancel(context.Background())
+		err := CancelAndWait(ctx)
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("CancelAndWait without WithCancel", func(t *testing.T) {
+		ctx := context.Background()
+		err := CancelAndWait(ctx)
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+}
+
+func TestCancelAndWaitWithTimeout(t *testing.T) {
+	t.Parallel()
+	ctx, _ := WithCancel(context.Background())
+
+	if err := Cleanup(ctx, func(ctx context.Context) error {
+		for i := 0; i < 10; i++ {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				time.Sleep(2 * time.Millisecond)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Error(err)
+	}
+
+	timeout := 5 * time.Millisecond
+
+	defer func() {
+		time.Sleep(10 * time.Millisecond)
+		if err := CancelAndWaitWithTimeout(ctx, timeout); !errors.Is(err, context.DeadlineExceeded) {
+			t.Error("expected timeout error")
+		}
+	}()
+}
+
+func TestCancelAndWaitWithContext(t *testing.T) {
+	t.Parallel()
+	ctx, _ := WithCancel(context.Background())
+
+	if err := Cleanup(ctx, func(ctx context.Context) error {
+		for i := 0; i < 10; i++ {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				time.Sleep(2 * time.Millisecond)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Error(err)
+	}
+
+	timeout := 5 * time.Millisecond
+
+	defer func() {
+		ctxx, cancelx := context.WithTimeout(context.Background(), timeout)
+		defer cancelx()
+		time.Sleep(10 * time.Millisecond)
+		if err := CancelAndWaitWithContext(ctx, ctxx); !errors.Is(err, context.DeadlineExceeded) {
+			t.Error("expected timeout error")
+		}
+	}()
+}


### PR DESCRIPTION
SSIA.

## Why not cancel context in `Wait(ctx)` ?

In the Go programming mindset, canceling a context is "canceling", not "waiting".


